### PR TITLE
feat: add PUT, HEAD, DELETE, and PATCH HTTP methods

### DIFF
--- a/src/Bundle/Form/SolidLoginType.php
+++ b/src/Bundle/Form/SolidLoginType.php
@@ -55,7 +55,7 @@ final class SolidLoginType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'constraints' => [new Callback(function (array $data, ExecutionContextInterface $context): void {
+            'constraints' => [new Callback(static function (array $data, ExecutionContextInterface $context): void {
                 $webId = $data['webid'] ?? '';
                 $op = $data['op'] ?? '';
 

--- a/src/SolidClient.php
+++ b/src/SolidClient.php
@@ -58,9 +58,42 @@ final class SolidClient
         return $this->request('POST', $url, $options);
     }
 
+    public function put(string $url, ?string $data = null, bool $isContainer = false, array $options = []): ResponseInterface
+    {
+        if (!isset($options['headers']['Content-Type'])) {
+            $options['headers']['Content-Type'] = self::DEFAULT_MIME_TYPE;
+        }
+        if (null !== $data) {
+            $options['body'] = $data;
+        }
+        if ($isContainer) {
+            $options['headers']['Link'] = \sprintf('<%s>; rel="type"', self::LDP_BASIC_CONTAINER);
+        }
+
+        return $this->request('PUT', $url, $options);
+    }
+
     public function get(string $url, array $options = []): ResponseInterface
     {
         return $this->request('GET', $url, $options);
+    }
+
+    public function head(string $url, array $options = []): ResponseInterface
+    {
+        return $this->request('HEAD', $url, $options);
+    }
+
+    public function delete(string $url, array $options = []): ResponseInterface
+    {
+        return $this->request('DELETE', $url, $options);
+    }
+
+    public function patch(string $url, string $data, string $contentType = 'application/sparql-update', array $options = []): ResponseInterface
+    {
+        $options['headers']['Content-Type'] = $contentType;
+        $options['body'] = $data;
+
+        return $this->request('PATCH', $url, $options);
     }
 
     public function request(string $method, string $url, array $options = []): ResponseInterface

--- a/src/SolidClient.php
+++ b/src/SolidClient.php
@@ -31,7 +31,7 @@ final class SolidClient
     ) {
     }
 
-    public function createContainer(string $parentUrl, string $name, string $data = null): ResponseInterface
+    public function createContainer(string $parentUrl, string $name, ?string $data = null): ResponseInterface
     {
         return $this->post($parentUrl, $data, $name, true);
     }
@@ -41,7 +41,7 @@ final class SolidClient
      *
      * @see https://github.com/solid/solid-web-client/blob/main/src/client.js#L231=
      */
-    public function post(string $url, string $data = null, string $slug = null, bool $isContainer = false, array $options = []): ResponseInterface
+    public function post(string $url, ?string $data = null, ?string $slug = null, bool $isContainer = false, array $options = []): ResponseInterface
     {
         if ($isContainer || !isset($options['headers']['Content-Type'])) {
             $options['headers']['Content-Type'] = self::DEFAULT_MIME_TYPE;
@@ -53,7 +53,7 @@ final class SolidClient
             $options['headers']['Slug'] = $slug;
         }
 
-        $options['headers']['Link'] = sprintf('<%s>; rel="type"', $isContainer ? self::LDP_BASIC_CONTAINER : self::LDP_RESOURCE);
+        $options['headers']['Link'] = \sprintf('<%s>; rel="type"', $isContainer ? self::LDP_BASIC_CONTAINER : self::LDP_RESOURCE);
 
         return $this->request('POST', $url, $options);
     }
@@ -88,7 +88,7 @@ final class SolidClient
     {
         $graph = $this->getProfile($webId, $options);
 
-        $issuer = $graph->get($webId, sprintf('<%s>', self::OIDC_ISSUER))?->getUri();
+        $issuer = $graph->get($webId, \sprintf('<%s>', self::OIDC_ISSUER))?->getUri();
         if (!\is_string($issuer)) {
             throw new Exception('Unable to find the OIDC issuer associated with this WebID', 1);
         }

--- a/src/SolidClientFactory.php
+++ b/src/SolidClientFactory.php
@@ -22,7 +22,7 @@ final class SolidClientFactory
     {
     }
 
-    public function create(OidcClient $oidcClient = null): SolidClient
+    public function create(?OidcClient $oidcClient = null): SolidClient
     {
         return new SolidClient($this->httpClient, $oidcClient);
     }

--- a/tests/SolidClientTest.php
+++ b/tests/SolidClientTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Solid Client PHP project.
+ * (c) Kévin Dunglas <kevin@dunglas.fr>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Dunglas\PhpSolidClient\Tests;
+
+use Dunglas\PhpSolidClient\SolidClient;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class SolidClientTest extends TestCase
+{
+    private static function findHeader(array $headers, string $name): ?string
+    {
+        $prefix = $name.': ';
+        foreach ($headers as $header) {
+            if (str_starts_with($header, $prefix)) {
+                return substr($header, \strlen($prefix));
+            }
+        }
+
+        return null;
+    }
+
+    public function testPut(): void
+    {
+        $response = new MockResponse('', ['http_code' => 201]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->put('http://pod.example/resource', '<> a <http://schema.org/Thing> .');
+
+        $this->assertSame('PUT', $response->getRequestMethod());
+        $this->assertSame('http://pod.example/resource', $response->getRequestUrl());
+        $this->assertSame('<> a <http://schema.org/Thing> .', $response->getRequestOptions()['body']);
+        $this->assertSame('text/turtle', self::findHeader($response->getRequestOptions()['headers'], 'Content-Type'));
+    }
+
+    public function testPutContainer(): void
+    {
+        $response = new MockResponse('', ['http_code' => 201]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->put('http://pod.example/container/', null, true);
+
+        $this->assertSame('PUT', $response->getRequestMethod());
+        $this->assertStringContainsString('ldp#BasicContainer', self::findHeader($response->getRequestOptions()['headers'], 'Link') ?? '');
+    }
+
+    public function testPutCustomContentType(): void
+    {
+        $response = new MockResponse('', ['http_code' => 201]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->put('http://pod.example/resource', '{}', false, [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertSame('application/ld+json', self::findHeader($response->getRequestOptions()['headers'], 'Content-Type'));
+    }
+
+    public function testHead(): void
+    {
+        $response = new MockResponse('', [
+            'http_code' => 200,
+            'response_headers' => [
+                'Content-Type' => 'text/turtle',
+                'Content-Length' => '1234',
+            ],
+        ]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->head('http://pod.example/resource');
+
+        $this->assertSame('HEAD', $response->getRequestMethod());
+        $this->assertSame('http://pod.example/resource', $response->getRequestUrl());
+    }
+
+    public function testDelete(): void
+    {
+        $response = new MockResponse('', ['http_code' => 200]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->delete('http://pod.example/resource');
+
+        $this->assertSame('DELETE', $response->getRequestMethod());
+        $this->assertSame('http://pod.example/resource', $response->getRequestUrl());
+    }
+
+    public function testPatchSparqlUpdate(): void
+    {
+        $sparql = 'INSERT DATA { <> <http://schema.org/name> "Test" . }';
+        $response = new MockResponse('', ['http_code' => 200]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->patch('http://pod.example/resource', $sparql);
+
+        $this->assertSame('PATCH', $response->getRequestMethod());
+        $this->assertSame($sparql, $response->getRequestOptions()['body']);
+        $this->assertSame('application/sparql-update', self::findHeader($response->getRequestOptions()['headers'], 'Content-Type'));
+    }
+
+    public function testPatchN3(): void
+    {
+        $n3Patch = '@prefix solid: <http://www.w3.org/ns/solid/terms#>. _:patch a solid:InsertDeletePatch .';
+        $response = new MockResponse('', ['http_code' => 200]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->patch('http://pod.example/resource', $n3Patch, 'text/n3');
+
+        $this->assertSame('text/n3', self::findHeader($response->getRequestOptions()['headers'], 'Content-Type'));
+    }
+
+    public function testPost(): void
+    {
+        $response = new MockResponse('', [
+            'http_code' => 201,
+            'response_headers' => ['Location' => 'http://pod.example/container/new-resource'],
+        ]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->post('http://pod.example/container/', '<> a <http://schema.org/Thing> .', 'new-resource');
+
+        $this->assertSame('POST', $response->getRequestMethod());
+        $this->assertSame('new-resource', self::findHeader($response->getRequestOptions()['headers'], 'Slug'));
+        $this->assertStringContainsString('ldp#Resource', self::findHeader($response->getRequestOptions()['headers'], 'Link') ?? '');
+    }
+
+    public function testGet(): void
+    {
+        $body = '<> a <http://schema.org/Thing> .';
+        $response = new MockResponse($body, ['http_code' => 200]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $result = $client->get('http://pod.example/resource');
+
+        $this->assertSame('GET', $response->getRequestMethod());
+        $this->assertSame($body, $result->getContent());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `put()`, `head()`, `delete()`, and `patch()` methods to `SolidClient`
- `put()` supports optional LDP BasicContainer Link header for container creation
- `patch()` defaults to `application/sparql-update`, also supports `text/n3` for N3 Patch
- Applies CS Fixer auto-fixes (explicit nullable types, `\sprintf`)

## Stack
1/8 — **This PR** → `main`

## Test plan
- [x] Unit tests for all 4 new methods with MockHttpClient
- [x] Existing SmokeTest still passes
- [x] CS Fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)