### PR TITLE
feat: add RFC 3986 relative IRI resolution

### DIFF
--- a/src/Bundle/Form/SolidLoginType.php
+++ b/src/Bundle/Form/SolidLoginType.php
@@ -55,7 +55,7 @@ final class SolidLoginType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'constraints' => [new Callback(function (array $data, ExecutionContextInterface $context): void {
+            'constraints' => [new Callback(static function (array $data, ExecutionContextInterface $context): void {
                 $webId = $data['webid'] ?? '';
                 $op = $data['op'] ?? '';
 

--- a/src/IriHelper.php
+++ b/src/IriHelper.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the Solid Client PHP project.
+ * (c) Kévin Dunglas <kevin@dunglas.fr>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Dunglas\PhpSolidClient;
+
+/**
+ * RFC 3986 §5 relative IRI resolution.
+ */
+final class IriHelper
+{
+    /**
+     * Resolves a relative reference against a base URI per RFC 3986 §5.3.
+     */
+    public static function resolve(string $base, string $reference): string
+    {
+        // If the reference is already absolute, return it
+        $r = self::parse($reference);
+        if (null !== $r['scheme']) {
+            return self::recompose(
+                $r['scheme'],
+                $r['authority'],
+                self::removeDotSegments($r['path']),
+                $r['query'],
+                $r['fragment'],
+            );
+        }
+
+        $b = self::parse($base);
+
+        if (null !== $r['authority']) {
+            return self::recompose(
+                $b['scheme'],
+                $r['authority'],
+                self::removeDotSegments($r['path']),
+                $r['query'],
+                $r['fragment'],
+            );
+        }
+
+        if ('' === $r['path']) {
+            $path = $b['path'];
+            $query = $r['query'] ?? $b['query'];
+        } else {
+            if (str_starts_with($r['path'], '/')) {
+                $path = self::removeDotSegments($r['path']);
+            } else {
+                $path = self::merge($b, $r['path']);
+                $path = self::removeDotSegments($path);
+            }
+            $query = $r['query'];
+        }
+
+        return self::recompose($b['scheme'], $b['authority'], $path, $query, $r['fragment']);
+    }
+
+    /**
+     * @return array{scheme: ?string, authority: ?string, path: string, query: ?string, fragment: ?string}
+     */
+    private static function parse(string $uri): array
+    {
+        // RFC 3986 Appendix B regex
+        preg_match('~^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?~', $uri, $m);
+
+        return [
+            'scheme' => isset($m[2]) && '' !== $m[2] ? $m[2] : null,
+            'authority' => isset($m[3]) && '' !== $m[3] ? $m[4] : null,
+            'path' => $m[5] ?? '',
+            'query' => isset($m[6]) && '' !== $m[6] ? $m[7] : null,
+            'fragment' => isset($m[8]) && '' !== $m[8] ? $m[9] : null,
+        ];
+    }
+
+    /**
+     * @param array{scheme: ?string, authority: ?string, path: string, query: ?string, fragment: ?string} $base
+     */
+    private static function merge(array $base, string $referencePath): string
+    {
+        if (null !== $base['authority'] && '' === $base['path']) {
+            return '/'.$referencePath;
+        }
+
+        $lastSlash = strrpos($base['path'], '/');
+
+        return false !== $lastSlash
+            ? substr($base['path'], 0, $lastSlash + 1).$referencePath
+            : $referencePath;
+    }
+
+    private static function removeDotSegments(string $path): string
+    {
+        $output = [];
+        $segments = explode('/', $path);
+        $absolute = str_starts_with($path, '/');
+        $trailingSlash = false;
+
+        foreach ($segments as $segment) {
+            if ('.' === $segment) {
+                $trailingSlash = true;
+                continue;
+            }
+            if ('..' === $segment) {
+                array_pop($output);
+                $trailingSlash = true;
+                continue;
+            }
+            $trailingSlash = false;
+            $output[] = $segment;
+        }
+
+        $result = implode('/', $output);
+        if ($trailingSlash && !str_ends_with($result, '/')) {
+            $result .= '/';
+        }
+
+        // Preserve leading slash for absolute paths
+        if ($absolute && !str_starts_with($result, '/')) {
+            $result = '/'.$result;
+        }
+
+        return $result;
+    }
+
+    private static function recompose(?string $scheme, ?string $authority, string $path, ?string $query, ?string $fragment): string
+    {
+        $result = '';
+        if (null !== $scheme) {
+            $result .= $scheme.':';
+        }
+        if (null !== $authority) {
+            $result .= '//'.$authority;
+        }
+        $result .= $path;
+        if (null !== $query) {
+            $result .= '?'.$query;
+        }
+        if (null !== $fragment) {
+            $result .= '#'.$fragment;
+        }
+
+        return $result;
+    }
+}

--- a/src/JsonLdParser.php
+++ b/src/JsonLdParser.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Solid Client PHP project.
+ * (c) Kévin Dunglas <kevin@dunglas.fr>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Dunglas\PhpSolidClient;
+
+/**
+ * Parses JSON-LD responses from Solid/CSS servers.
+ *
+ * CSS returns expanded JSON-LD by default for Accept: application/ld+json,
+ * so a full JSON-LD processor is not needed — json_decode is sufficient.
+ * Relative @id values should be resolved using IriHelper.
+ */
+final class JsonLdParser
+{
+    /**
+     * Parses a JSON-LD string into an array of node arrays.
+     *
+     * Handles both single objects and arrays of objects.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public static function parse(string $jsonLd): array
+    {
+        $decoded = json_decode($jsonLd, true, 512, \JSON_THROW_ON_ERROR);
+
+        // If it's a single object (has @id or @type), wrap in array
+        if (isset($decoded['@id']) || isset($decoded['@type'])) {
+            return [$decoded];
+        }
+
+        // If it's an array of objects (expanded form)
+        if (array_is_list($decoded)) {
+            return $decoded;
+        }
+
+        return [$decoded];
+    }
+
+    /**
+     * Finds a node by @id in parsed JSON-LD.
+     *
+     * @param list<array<string, mixed>> $nodes
+     *
+     * @return array<string, mixed>|null
+     */
+    public static function findById(array $nodes, string $id): ?array
+    {
+        foreach ($nodes as $node) {
+            if (($node['@id'] ?? null) === $id) {
+                return $node;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ResourceMetadata.php
+++ b/src/ResourceMetadata.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Solid Client PHP project.
+ * (c) Kévin Dunglas <kevin@dunglas.fr>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Dunglas\PhpSolidClient;
+
+final class ResourceMetadata
+{
+    /**
+     * @param array<string, list<string>> $wacAllow parsed WAC-Allow header (e.g. ['user' => ['read', 'write'], 'public' => ['read']])
+     */
+    public function __construct(
+        public readonly ?string $contentType = null,
+        public readonly ?int $contentLength = null,
+        public readonly ?\DateTimeImmutable $lastModified = null,
+        public readonly ?string $ldpType = null,
+        public readonly array $wacAllow = [],
+        public readonly ?string $aclUrl = null,
+    ) {
+    }
+
+    public function isContainer(): bool
+    {
+        return 'http://www.w3.org/ns/ldp#BasicContainer' === $this->ldpType
+            || 'http://www.w3.org/ns/ldp#Container' === $this->ldpType;
+    }
+
+    /**
+     * @param array<string, list<string>> $responseHeaders normalized response headers
+     */
+    public static function fromResponseHeaders(array $responseHeaders): self
+    {
+        $contentType = isset($responseHeaders['content-type'][0])
+            ? explode(';', $responseHeaders['content-type'][0], 2)[0]
+            : null;
+
+        $contentLength = isset($responseHeaders['content-length'][0])
+            ? (int) $responseHeaders['content-length'][0]
+            : null;
+
+        $lastModified = isset($responseHeaders['last-modified'][0])
+            ? \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC7231, $responseHeaders['last-modified'][0]) ?: null
+            : null;
+
+        $ldpType = null;
+        $aclUrl = null;
+        foreach ($responseHeaders['link'] ?? [] as $linkHeader) {
+            foreach (explode(',', $linkHeader) as $link) {
+                $link = trim($link);
+                if (preg_match('/<([^>]+)>;\s*rel="type"/', $link, $matches)) {
+                    if (str_contains($matches[1], 'ldp#')) {
+                        $ldpType = $matches[1];
+                    }
+                }
+                if (preg_match('/<([^>]+)>;\s*rel="acl"/', $link, $matches)) {
+                    $aclUrl = $matches[1];
+                }
+            }
+        }
+
+        $wacAllow = [];
+        if (isset($responseHeaders['wac-allow'][0])) {
+            // Format: user="read write append control",public="read"
+            if (preg_match_all('/(\w+)="([^"]*)"/', $responseHeaders['wac-allow'][0], $matches, \PREG_SET_ORDER)) {
+                foreach ($matches as $match) {
+                    $wacAllow[$match[1]] = array_filter(explode(' ', $match[2]));
+                }
+            }
+        }
+
+        return new self($contentType, $contentLength, $lastModified, $ldpType, $wacAllow, $aclUrl);
+    }
+}

--- a/src/SolidClient.php
+++ b/src/SolidClient.php
@@ -31,7 +31,7 @@ final class SolidClient
     ) {
     }
 
-    public function createContainer(string $parentUrl, string $name, string $data = null): ResponseInterface
+    public function createContainer(string $parentUrl, string $name, ?string $data = null): ResponseInterface
     {
         return $this->post($parentUrl, $data, $name, true);
     }
@@ -41,7 +41,7 @@ final class SolidClient
      *
      * @see https://github.com/solid/solid-web-client/blob/main/src/client.js#L231=
      */
-    public function post(string $url, string $data = null, string $slug = null, bool $isContainer = false, array $options = []): ResponseInterface
+    public function post(string $url, ?string $data = null, ?string $slug = null, bool $isContainer = false, array $options = []): ResponseInterface
     {
         if ($isContainer || !isset($options['headers']['Content-Type'])) {
             $options['headers']['Content-Type'] = self::DEFAULT_MIME_TYPE;
@@ -53,14 +53,47 @@ final class SolidClient
             $options['headers']['Slug'] = $slug;
         }
 
-        $options['headers']['Link'] = sprintf('<%s>; rel="type"', $isContainer ? self::LDP_BASIC_CONTAINER : self::LDP_RESOURCE);
+        $options['headers']['Link'] = \sprintf('<%s>; rel="type"', $isContainer ? self::LDP_BASIC_CONTAINER : self::LDP_RESOURCE);
 
         return $this->request('POST', $url, $options);
+    }
+
+    public function put(string $url, ?string $data = null, bool $isContainer = false, array $options = []): ResponseInterface
+    {
+        if (!isset($options['headers']['Content-Type'])) {
+            $options['headers']['Content-Type'] = self::DEFAULT_MIME_TYPE;
+        }
+        if (null !== $data) {
+            $options['body'] = $data;
+        }
+        if ($isContainer) {
+            $options['headers']['Link'] = \sprintf('<%s>; rel="type"', self::LDP_BASIC_CONTAINER);
+        }
+
+        return $this->request('PUT', $url, $options);
     }
 
     public function get(string $url, array $options = []): ResponseInterface
     {
         return $this->request('GET', $url, $options);
+    }
+
+    public function head(string $url, array $options = []): ResponseInterface
+    {
+        return $this->request('HEAD', $url, $options);
+    }
+
+    public function delete(string $url, array $options = []): ResponseInterface
+    {
+        return $this->request('DELETE', $url, $options);
+    }
+
+    public function patch(string $url, string $data, string $contentType = 'application/sparql-update', array $options = []): ResponseInterface
+    {
+        $options['headers']['Content-Type'] = $contentType;
+        $options['body'] = $data;
+
+        return $this->request('PATCH', $url, $options);
     }
 
     public function request(string $method, string $url, array $options = []): ResponseInterface
@@ -88,7 +121,7 @@ final class SolidClient
     {
         $graph = $this->getProfile($webId, $options);
 
-        $issuer = $graph->get($webId, sprintf('<%s>', self::OIDC_ISSUER))?->getUri();
+        $issuer = $graph->get($webId, \sprintf('<%s>', self::OIDC_ISSUER))?->getUri();
         if (!\is_string($issuer)) {
             throw new Exception('Unable to find the OIDC issuer associated with this WebID', 1);
         }

--- a/src/SolidClient.php
+++ b/src/SolidClient.php
@@ -96,6 +96,13 @@ final class SolidClient
         return $this->request('PATCH', $url, $options);
     }
 
+    public function getResourceMetadata(string $url, array $options = []): ResourceMetadata
+    {
+        $response = $this->head($url, $options);
+
+        return ResourceMetadata::fromResponseHeaders($response->getHeaders(false));
+    }
+
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
         if ($accessToken = $this->oidcClient?->getAccessToken()) {

--- a/src/SolidClientFactory.php
+++ b/src/SolidClientFactory.php
@@ -22,7 +22,7 @@ final class SolidClientFactory
     {
     }
 
-    public function create(OidcClient $oidcClient = null): SolidClient
+    public function create(?OidcClient $oidcClient = null): SolidClient
     {
         return new SolidClient($this->httpClient, $oidcClient);
     }

--- a/tests/IriHelperTest.php
+++ b/tests/IriHelperTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Solid Client PHP project.
+ * (c) Kévin Dunglas <kevin@dunglas.fr>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Dunglas\PhpSolidClient\Tests;
+
+use Dunglas\PhpSolidClient\IriHelper;
+use PHPUnit\Framework\TestCase;
+
+class IriHelperTest extends TestCase
+{
+    private const BASE = 'http://a/b/c/d;p?q';
+
+    /**
+     * RFC 3986 §5.4 — Normal examples.
+     *
+     * @dataProvider rfc3986NormalExamplesProvider
+     */
+    public function testRfc3986NormalExamples(string $reference, string $expected): void
+    {
+        $this->assertSame($expected, IriHelper::resolve(self::BASE, $reference));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function rfc3986NormalExamplesProvider(): iterable
+    {
+        yield 'g:h' => ['g:h', 'g:h'];
+        yield 'g' => ['g', 'http://a/b/c/g'];
+        yield './g' => ['./g', 'http://a/b/c/g'];
+        yield 'g/' => ['g/', 'http://a/b/c/g/'];
+        yield '/g' => ['/g', 'http://a/g'];
+        yield '//g' => ['//g', 'http://g'];
+        yield '?y' => ['?y', 'http://a/b/c/d;p?y'];
+        yield 'g?y' => ['g?y', 'http://a/b/c/g?y'];
+        yield '#s' => ['#s', 'http://a/b/c/d;p?q#s'];
+        yield 'g#s' => ['g#s', 'http://a/b/c/g#s'];
+        yield 'g?y#s' => ['g?y#s', 'http://a/b/c/g?y#s'];
+        yield ';x' => [';x', 'http://a/b/c/;x'];
+        yield 'g;x' => ['g;x', 'http://a/b/c/g;x'];
+        yield 'g;x?y#s' => ['g;x?y#s', 'http://a/b/c/g;x?y#s'];
+        yield 'empty' => ['', 'http://a/b/c/d;p?q'];
+        yield '.' => ['.', 'http://a/b/c/'];
+        yield './' => ['./', 'http://a/b/c/'];
+        yield '..' => ['..', 'http://a/b/'];
+        yield '../' => ['../', 'http://a/b/'];
+        yield '../g' => ['../g', 'http://a/b/g'];
+        yield '../..' => ['../..', 'http://a/'];
+        yield '../../' => ['../../', 'http://a/'];
+        yield '../../g' => ['../../g', 'http://a/g'];
+    }
+
+    public function testSolidPodRelativeId(): void
+    {
+        $base = 'http://localhost:3000/test/';
+        $this->assertSame('http://localhost:3000/test/file.ttl', IriHelper::resolve($base, 'file.ttl'));
+        $this->assertSame('http://localhost:3000/test/sub/', IriHelper::resolve($base, 'sub/'));
+    }
+
+    public function testAbsoluteReferenceUnchanged(): void
+    {
+        $this->assertSame(
+            'https://other.example/path',
+            IriHelper::resolve('http://example.com/base/', 'https://other.example/path'),
+        );
+    }
+}

--- a/tests/JsonLdParserTest.php
+++ b/tests/JsonLdParserTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Solid Client PHP project.
+ * (c) Kévin Dunglas <kevin@dunglas.fr>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Dunglas\PhpSolidClient\Tests;
+
+use Dunglas\PhpSolidClient\JsonLdParser;
+use PHPUnit\Framework\TestCase;
+
+class JsonLdParserTest extends TestCase
+{
+    public function testParseSingleObject(): void
+    {
+        $jsonLd = json_encode([
+            '@id' => 'http://example.com/thing',
+            '@type' => ['http://schema.org/Thing'],
+            'http://schema.org/name' => [['@value' => 'Test']],
+        ]);
+
+        $result = JsonLdParser::parse($jsonLd);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('http://example.com/thing', $result[0]['@id']);
+    }
+
+    public function testParseExpandedArray(): void
+    {
+        $jsonLd = json_encode([
+            [
+                '@id' => 'http://example.com/a',
+                '@type' => ['http://schema.org/Thing'],
+            ],
+            [
+                '@id' => 'http://example.com/b',
+            ],
+        ]);
+
+        $result = JsonLdParser::parse($jsonLd);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('http://example.com/a', $result[0]['@id']);
+        $this->assertSame('http://example.com/b', $result[1]['@id']);
+    }
+
+    public function testParseLdpContainer(): void
+    {
+        $jsonLd = json_encode([
+            '@id' => 'http://pod.example/container/',
+            '@type' => ['http://www.w3.org/ns/ldp#BasicContainer'],
+            'http://www.w3.org/ns/ldp#contains' => [
+                ['@id' => 'file.txt'],
+                ['@id' => 'sub/', '@type' => ['http://www.w3.org/ns/ldp#BasicContainer']],
+            ],
+        ]);
+
+        $result = JsonLdParser::parse($jsonLd);
+
+        $this->assertCount(1, $result);
+        $contains = $result[0]['http://www.w3.org/ns/ldp#contains'];
+        $this->assertCount(2, $contains);
+        $this->assertSame('file.txt', $contains[0]['@id']);
+        $this->assertSame('sub/', $contains[1]['@id']);
+    }
+
+    public function testFindById(): void
+    {
+        $nodes = [
+            ['@id' => 'http://example.com/a', 'name' => 'A'],
+            ['@id' => 'http://example.com/b', 'name' => 'B'],
+        ];
+
+        $found = JsonLdParser::findById($nodes, 'http://example.com/b');
+
+        $this->assertNotNull($found);
+        $this->assertSame('B', $found['name']);
+
+        $this->assertNull(JsonLdParser::findById($nodes, 'http://example.com/c'));
+    }
+}

--- a/tests/ResourceMetadataTest.php
+++ b/tests/ResourceMetadataTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Solid Client PHP project.
+ * (c) Kévin Dunglas <kevin@dunglas.fr>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Dunglas\PhpSolidClient\Tests;
+
+use Dunglas\PhpSolidClient\ResourceMetadata;
+use PHPUnit\Framework\TestCase;
+
+class ResourceMetadataTest extends TestCase
+{
+    public function testFromResponseHeaders(): void
+    {
+        $headers = [
+            'content-type' => ['text/turtle; charset=utf-8'],
+            'content-length' => ['4567'],
+            'last-modified' => ['Mon, 23 Feb 2026 12:00:00 GMT'],
+            'link' => [
+                '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"',
+                '<http://pod.example/resource.acl>; rel="acl"',
+            ],
+            'wac-allow' => ['user="read write append control",public="read"'],
+        ];
+
+        $metadata = ResourceMetadata::fromResponseHeaders($headers);
+
+        $this->assertSame('text/turtle', $metadata->contentType);
+        $this->assertSame(4567, $metadata->contentLength);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $metadata->lastModified);
+        $this->assertSame('http://www.w3.org/ns/ldp#BasicContainer', $metadata->ldpType);
+        $this->assertTrue($metadata->isContainer());
+        $this->assertSame('http://pod.example/resource.acl', $metadata->aclUrl);
+        $this->assertSame(['read', 'write', 'append', 'control'], $metadata->wacAllow['user']);
+        $this->assertSame(['read'], $metadata->wacAllow['public']);
+    }
+
+    public function testResourceNotContainer(): void
+    {
+        $headers = [
+            'content-type' => ['application/ld+json'],
+            'link' => ['<http://www.w3.org/ns/ldp#Resource>; rel="type"'],
+        ];
+
+        $metadata = ResourceMetadata::fromResponseHeaders($headers);
+
+        $this->assertFalse($metadata->isContainer());
+        $this->assertSame('http://www.w3.org/ns/ldp#Resource', $metadata->ldpType);
+    }
+
+    public function testEmptyHeaders(): void
+    {
+        $metadata = ResourceMetadata::fromResponseHeaders([]);
+
+        $this->assertNull($metadata->contentType);
+        $this->assertNull($metadata->contentLength);
+        $this->assertNull($metadata->lastModified);
+        $this->assertNull($metadata->ldpType);
+        $this->assertNull($metadata->aclUrl);
+        $this->assertSame([], $metadata->wacAllow);
+    }
+}

--- a/tests/SolidClientTest.php
+++ b/tests/SolidClientTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Solid Client PHP project.
+ * (c) Kévin Dunglas <kevin@dunglas.fr>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Dunglas\PhpSolidClient\Tests;
+
+use Dunglas\PhpSolidClient\SolidClient;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class SolidClientTest extends TestCase
+{
+    private static function findHeader(array $headers, string $name): ?string
+    {
+        $prefix = $name.': ';
+        foreach ($headers as $header) {
+            if (str_starts_with($header, $prefix)) {
+                return substr($header, \strlen($prefix));
+            }
+        }
+
+        return null;
+    }
+
+    public function testPut(): void
+    {
+        $response = new MockResponse('', ['http_code' => 201]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->put('http://pod.example/resource', '<> a <http://schema.org/Thing> .');
+
+        $this->assertSame('PUT', $response->getRequestMethod());
+        $this->assertSame('http://pod.example/resource', $response->getRequestUrl());
+        $this->assertSame('<> a <http://schema.org/Thing> .', $response->getRequestOptions()['body']);
+        $this->assertSame('text/turtle', self::findHeader($response->getRequestOptions()['headers'], 'Content-Type'));
+    }
+
+    public function testPutContainer(): void
+    {
+        $response = new MockResponse('', ['http_code' => 201]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->put('http://pod.example/container/', null, true);
+
+        $this->assertSame('PUT', $response->getRequestMethod());
+        $this->assertStringContainsString('ldp#BasicContainer', self::findHeader($response->getRequestOptions()['headers'], 'Link') ?? '');
+    }
+
+    public function testPutCustomContentType(): void
+    {
+        $response = new MockResponse('', ['http_code' => 201]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->put('http://pod.example/resource', '{}', false, [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+        ]);
+
+        $this->assertSame('application/ld+json', self::findHeader($response->getRequestOptions()['headers'], 'Content-Type'));
+    }
+
+    public function testHead(): void
+    {
+        $response = new MockResponse('', [
+            'http_code' => 200,
+            'response_headers' => [
+                'Content-Type' => 'text/turtle',
+                'Content-Length' => '1234',
+            ],
+        ]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->head('http://pod.example/resource');
+
+        $this->assertSame('HEAD', $response->getRequestMethod());
+        $this->assertSame('http://pod.example/resource', $response->getRequestUrl());
+    }
+
+    public function testDelete(): void
+    {
+        $response = new MockResponse('', ['http_code' => 200]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->delete('http://pod.example/resource');
+
+        $this->assertSame('DELETE', $response->getRequestMethod());
+        $this->assertSame('http://pod.example/resource', $response->getRequestUrl());
+    }
+
+    public function testPatchSparqlUpdate(): void
+    {
+        $sparql = 'INSERT DATA { <> <http://schema.org/name> "Test" . }';
+        $response = new MockResponse('', ['http_code' => 200]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->patch('http://pod.example/resource', $sparql);
+
+        $this->assertSame('PATCH', $response->getRequestMethod());
+        $this->assertSame($sparql, $response->getRequestOptions()['body']);
+        $this->assertSame('application/sparql-update', self::findHeader($response->getRequestOptions()['headers'], 'Content-Type'));
+    }
+
+    public function testPatchN3(): void
+    {
+        $n3Patch = '@prefix solid: <http://www.w3.org/ns/solid/terms#>. _:patch a solid:InsertDeletePatch .';
+        $response = new MockResponse('', ['http_code' => 200]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->patch('http://pod.example/resource', $n3Patch, 'text/n3');
+
+        $this->assertSame('text/n3', self::findHeader($response->getRequestOptions()['headers'], 'Content-Type'));
+    }
+
+    public function testPost(): void
+    {
+        $response = new MockResponse('', [
+            'http_code' => 201,
+            'response_headers' => ['Location' => 'http://pod.example/container/new-resource'],
+        ]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $client->post('http://pod.example/container/', '<> a <http://schema.org/Thing> .', 'new-resource');
+
+        $this->assertSame('POST', $response->getRequestMethod());
+        $this->assertSame('new-resource', self::findHeader($response->getRequestOptions()['headers'], 'Slug'));
+        $this->assertStringContainsString('ldp#Resource', self::findHeader($response->getRequestOptions()['headers'], 'Link') ?? '');
+    }
+
+    public function testGet(): void
+    {
+        $body = '<> a <http://schema.org/Thing> .';
+        $response = new MockResponse($body, ['http_code' => 200]);
+        $httpClient = new MockHttpClient($response);
+        $client = new SolidClient($httpClient);
+
+        $result = $client->get('http://pod.example/resource');
+
+        $this->assertSame('GET', $response->getRequestMethod());
+        $this->assertSame($body, $result->getContent());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `IriHelper::resolve()` implementing RFC 3986 §5 relative reference resolution
- Needed because CSS JSON-LD responses may contain relative `@id` values
- Handles all RFC 3986 edge cases: dot segments, authority-relative, query/fragment

## Stack
4/8 — builds on #8 (`feat/jsonld-parsing`)

## Test plan
- [x] Full RFC 3986 §5.4 normal examples via data provider (22 cases)
- [x] Solid Pod-specific relative ID resolution tests
- [x] Absolute reference passthrough test

🤖 Generated with [Claude Code](https://claude.com/claude-code)